### PR TITLE
Make SPARQL UPDATE queries apply to documents directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -753,37 +753,37 @@
       }
     },
     "@comunica/actor-abstract-path": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.4.4.tgz",
-      "integrity": "sha512-vIzAfD65P7hzEUzQz70ENnwaSIfgMJGVy2ICHi8ONp+TmL2xn+8ewbjlUmJEpSjyv9GMRtWS5203qljYVio/sg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-abstract-path/-/actor-abstract-path-1.4.5.tgz",
+      "integrity": "sha512-NDFaA880vcpxnRZaZrOKi/8jN7bYc0cx07PZhMP59BcIvaLJA6V7BuJNegQeeKDPA0K/mkMsWztq6nsvLYHkuQ==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "asynciterator": "^2.0.1",
         "rdf-string": "^1.3.1",
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-context-preprocess-rdf-source-identifier": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-rdf-source-identifier/-/actor-context-preprocess-rdf-source-identifier-1.4.0.tgz",
-      "integrity": "sha512-NdR1XNjFyYg+e2L+YScKFEl7Y4MdDd/9cd8catsEqxymxLVmQjRVltP7QhAt5TPvake5pQmynpl547SwYeg4Rg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-context-preprocess-rdf-source-identifier/-/actor-context-preprocess-rdf-source-identifier-1.5.4.tgz",
+      "integrity": "sha512-21vQ0T7YNqd8Xzew2Gbmyo3dG2BjRUWtpqWDheqlZn6mWoCzi6D66RFsNfM9Uz+QjxwSCXVtPwsdx5GXNXCNQA==",
       "requires": {
-        "asyncreiterable": "^1.1.0"
+        "asyncreiterable": "^1.1.1"
       }
     },
     "@comunica/actor-http-memento": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.4.0.tgz",
-      "integrity": "sha512-MhOlPeAo9U3VRRIMo/giCJo6Mhmc/g8EPCfT0bo5WHvMdO+Mpepm9QSxvhC0CkqOf62mb58pddzCj7SeehOkYQ==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-memento/-/actor-http-memento-1.5.1.tgz",
+      "integrity": "sha512-0uqMxG7/82kG/RHSzVfGvZbs2e6II/j/Kj2Afhn1ouAbrJOIJU3BVtqJ0UfK16ipiVJPD6/YOz8fkaO2SArzpA==",
       "requires": {
         "isomorphic-fetch": "^2.2.1",
         "parse-link-header": "^1.0.1"
       }
     },
     "@comunica/actor-http-native": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.4.4.tgz",
-      "integrity": "sha512-Gk8gqd8JBHWzT/M8IOuKdOR9toYmIhim0lx6F4uNDAEIxjvNp2e6pKMpskeHRwJvi4TKNMrv+k/k1AhwhdTYxw==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-http-native/-/actor-http-native-1.5.1.tgz",
+      "integrity": "sha512-IhH2CVf33pw5S35VSFIxefmkT8t04/7dqNtgeKNMH1PDlyeLqWsFk32KhZ0CwUr9Q/FaejhQK+pYTcTK3iEpOg==",
       "requires": {
         "follow-redirects": "^1.5.1",
         "isomorphic-fetch": "^2.2.1",
@@ -791,65 +791,68 @@
       }
     },
     "@comunica/actor-init-sparql": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.4.4.tgz",
-      "integrity": "sha512-BOwZ/Db+nt+tO4aL1H7D0JLpv/6y/uY4SqUxsEj9T02nGm/5EERpxWdoxc2xs/sfymymnoLtrICAryH+NSL3Tw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-init-sparql/-/actor-init-sparql-1.5.4.tgz",
+      "integrity": "sha512-WFSVBlSUsU9jjnK33ur34427DzKRtKGU6FGp1GwlnflDigdypfgt1iCOp+al3mvruguqq/XgOY6brJfqleuRqw==",
       "requires": {
         "@comunica/actor-abstract-bindings-hash": "^1.4.4",
         "@comunica/actor-abstract-mediatyped": "^1.4.0",
-        "@comunica/actor-context-preprocess-rdf-source-identifier": "^1.4.0",
-        "@comunica/actor-http-memento": "^1.4.0",
-        "@comunica/actor-http-native": "^1.4.4",
+        "@comunica/actor-context-preprocess-rdf-source-identifier": "^1.5.4",
+        "@comunica/actor-http-memento": "^1.5.1",
+        "@comunica/actor-http-native": "^1.5.1",
+        "@comunica/actor-optimize-query-operation-join-bgp": "^1.5.0",
         "@comunica/actor-query-operation-ask": "^1.4.4",
         "@comunica/actor-query-operation-bgp-empty": "^1.4.4",
-        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.4.4",
+        "@comunica/actor-query-operation-bgp-left-deep-smallest": "^1.4.5",
         "@comunica/actor-query-operation-bgp-single": "^1.4.4",
         "@comunica/actor-query-operation-construct": "^1.4.4",
         "@comunica/actor-query-operation-describe-subject": "^1.4.4",
         "@comunica/actor-query-operation-distinct-hash": "^1.4.4",
-        "@comunica/actor-query-operation-filter-direct": "^1.4.4",
-        "@comunica/actor-query-operation-from-quad": "^1.4.4",
+        "@comunica/actor-query-operation-extend": "^1.5.2",
+        "@comunica/actor-query-operation-filter-sparqlee": "^1.5.1",
+        "@comunica/actor-query-operation-from-quad": "^1.4.5",
         "@comunica/actor-query-operation-join": "^1.4.4",
-        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.4.4",
+        "@comunica/actor-query-operation-leftjoin-nestedloop": "^1.5.1",
         "@comunica/actor-query-operation-minus": "^1.4.4",
-        "@comunica/actor-query-operation-orderby-direct": "^1.4.4",
-        "@comunica/actor-query-operation-path-alt": "^1.4.4",
-        "@comunica/actor-query-operation-path-inv": "^1.4.4",
-        "@comunica/actor-query-operation-path-link": "^1.4.4",
-        "@comunica/actor-query-operation-path-nps": "^1.4.4",
-        "@comunica/actor-query-operation-path-one-or-more": "^1.4.4",
-        "@comunica/actor-query-operation-path-seq": "^1.4.4",
-        "@comunica/actor-query-operation-path-zero-or-more": "^1.4.4",
-        "@comunica/actor-query-operation-path-zero-or-one": "^1.4.4",
+        "@comunica/actor-query-operation-orderby-sparqlee": "^1.5.1",
+        "@comunica/actor-query-operation-path-alt": "^1.4.5",
+        "@comunica/actor-query-operation-path-inv": "^1.4.5",
+        "@comunica/actor-query-operation-path-link": "^1.4.5",
+        "@comunica/actor-query-operation-path-nps": "^1.4.5",
+        "@comunica/actor-query-operation-path-one-or-more": "^1.4.5",
+        "@comunica/actor-query-operation-path-seq": "^1.4.5",
+        "@comunica/actor-query-operation-path-zero-or-more": "^1.4.5",
+        "@comunica/actor-query-operation-path-zero-or-one": "^1.4.5",
         "@comunica/actor-query-operation-project": "^1.4.4",
-        "@comunica/actor-query-operation-quadpattern": "^1.4.4",
-        "@comunica/actor-query-operation-reduced-hash": "^1.4.4",
+        "@comunica/actor-query-operation-quadpattern": "^1.5.4",
+        "@comunica/actor-query-operation-reduced-hash": "^1.4.5",
         "@comunica/actor-query-operation-service": "^1.4.4",
         "@comunica/actor-query-operation-slice": "^1.4.4",
-        "@comunica/actor-query-operation-sparql-endpoint": "^1.4.4",
+        "@comunica/actor-query-operation-sparql-endpoint": "^1.5.4",
         "@comunica/actor-query-operation-union": "^1.4.4",
         "@comunica/actor-query-operation-values": "^1.4.4",
-        "@comunica/actor-rdf-dereference-http-parse": "^1.4.2",
-        "@comunica/actor-rdf-dereference-paged-next": "^1.4.4",
+        "@comunica/actor-rdf-dereference-http-parse": "^1.5.1",
+        "@comunica/actor-rdf-dereference-paged-next": "^1.4.5",
         "@comunica/actor-rdf-join-nestedloop": "^1.4.4",
         "@comunica/actor-rdf-metadata-extract-hydra-controls": "^1.4.0",
         "@comunica/actor-rdf-metadata-extract-hydra-count": "^1.4.0",
         "@comunica/actor-rdf-metadata-primary-topic": "^1.4.0",
         "@comunica/actor-rdf-metadata-triple-predicate": "^1.4.0",
-        "@comunica/actor-rdf-parse-jsonld": "^1.4.3",
+        "@comunica/actor-rdf-parse-jsonld": "^1.5.4",
         "@comunica/actor-rdf-parse-n3": "^1.4.3",
         "@comunica/actor-rdf-parse-rdfxml": "^1.4.3",
-        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.4.4",
-        "@comunica/actor-rdf-resolve-quad-pattern-file": "^1.4.4",
-        "@comunica/actor-rdf-resolve-quad-pattern-qpf": "^1.4.4",
-        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.4.4",
-        "@comunica/actor-rdf-serialize-jsonld": "^1.4.0",
+        "@comunica/actor-rdf-resolve-hypermedia-qpf": "^1.5.4",
+        "@comunica/actor-rdf-resolve-quad-pattern-federated": "^1.5.4",
+        "@comunica/actor-rdf-resolve-quad-pattern-file": "^1.5.4",
+        "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": "^1.5.4",
+        "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": "^1.5.4",
+        "@comunica/actor-rdf-serialize-jsonld": "^1.5.4",
         "@comunica/actor-rdf-serialize-n3": "^1.4.3",
-        "@comunica/actor-rdf-source-identifier-file-content-type": "^1.4.0",
-        "@comunica/actor-rdf-source-identifier-hypermedia-qpf": "^1.4.0",
-        "@comunica/actor-rdf-source-identifier-sparql": "^1.4.0",
-        "@comunica/actor-sparql-parse-algebra": "^1.4.3",
-        "@comunica/actor-sparql-parse-graphql": "^1.4.3",
+        "@comunica/actor-rdf-source-identifier-file-content-type": "^1.5.1",
+        "@comunica/actor-rdf-source-identifier-hypermedia-qpf": "^1.5.1",
+        "@comunica/actor-rdf-source-identifier-sparql": "^1.5.1",
+        "@comunica/actor-sparql-parse-algebra": "^1.5.3",
+        "@comunica/actor-sparql-parse-graphql": "^1.5.3",
         "@comunica/actor-sparql-serialize-json": "^1.4.4",
         "@comunica/actor-sparql-serialize-rdf": "^1.4.4",
         "@comunica/actor-sparql-serialize-simple": "^1.4.4",
@@ -859,8 +862,9 @@
         "@comunica/actor-sparql-serialize-table": "^1.4.4",
         "@comunica/actor-sparql-serialize-tree": "^1.4.4",
         "@comunica/bus-context-preprocess": "^1.4.0",
-        "@comunica/bus-http": "^1.4.0",
+        "@comunica/bus-http": "^1.5.1",
         "@comunica/bus-init": "^1.4.0",
+        "@comunica/bus-optimize-query-operation": "^1.5.0",
         "@comunica/bus-query-operation": "^1.4.4",
         "@comunica/bus-rdf-dereference": "^1.4.0",
         "@comunica/bus-rdf-dereference-paged": "^1.4.0",
@@ -868,9 +872,10 @@
         "@comunica/bus-rdf-metadata": "^1.4.0",
         "@comunica/bus-rdf-metadata-extract": "^1.4.0",
         "@comunica/bus-rdf-parse": "^1.4.2",
-        "@comunica/bus-rdf-resolve-quad-pattern": "^1.4.4",
+        "@comunica/bus-rdf-resolve-hypermedia": "^1.5.4",
+        "@comunica/bus-rdf-resolve-quad-pattern": "^1.5.4",
         "@comunica/bus-rdf-serialize": "^1.4.0",
-        "@comunica/bus-rdf-source-identifier": "^1.4.0",
+        "@comunica/bus-rdf-source-identifier": "^1.5.1",
         "@comunica/bus-sparql-parse": "^1.4.0",
         "@comunica/bus-sparql-serialize": "^1.4.4",
         "@comunica/core": "^1.4.0",
@@ -882,12 +887,20 @@
         "@comunica/mediator-race": "^1.4.0",
         "@comunica/runner": "^1.4.4",
         "@comunica/runner-cli": "^1.4.4",
-        "asyncreiterable": "^1.1.0",
+        "asyncreiterable": "^1.1.1",
         "minimist": "^1.2.0",
         "negotiate": "^1.0.1",
         "rdf-string": "^1.3.1",
         "rdf-terms": "^1.4.0",
         "streamify-string": "^1.0.1"
+      }
+    },
+    "@comunica/actor-optimize-query-operation-join-bgp": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-optimize-query-operation-join-bgp/-/actor-optimize-query-operation-join-bgp-1.5.0.tgz",
+      "integrity": "sha512-PBMbOahhuHqUqTjqqqqibS6SorJGihxTPSEiSpJ6cAENWXwKqLzc1/M+5p4ToGOK1t7JrlsPcwbBmxqlWZLySg==",
+      "requires": {
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-ask": {
@@ -904,9 +917,9 @@
       }
     },
     "@comunica/actor-query-operation-bgp-left-deep-smallest": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.4.4.tgz",
-      "integrity": "sha512-vaTekxDxF1zf7FDFnOJbEyzrd+AYBjI27MZFthFgAjQc89mNmxwCn1W0lQxc+MK1KTcoTyA2+g1M5Uz214bpcQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-bgp-left-deep-smallest/-/actor-query-operation-bgp-left-deep-smallest-1.4.5.tgz",
+      "integrity": "sha512-5IVoDX0upYMM0p8ibnxeqtrnIvhJPTitsEB240Jr+cMHqNYLwcSncwh9pU7tGKtqhzYgeYZKXEp0Ju+9aviAKQ==",
       "requires": {
         "asynciterator-promiseproxy": "^2.0.0",
         "lodash.uniq": "^4.5.0",
@@ -948,21 +961,29 @@
         "json-stable-stringify": "^1.0.1"
       }
     },
-    "@comunica/actor-query-operation-filter-direct": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-direct/-/actor-query-operation-filter-direct-1.4.4.tgz",
-      "integrity": "sha512-FMou+bJbtofrz410YnLrAtheJQ8QjZWnwJG4sXtW2Y9I+dfWKNaV4UF1YCYfcBsSNNSYYvEhJH+3wVjiY/hh8A==",
+    "@comunica/actor-query-operation-extend": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-extend/-/actor-query-operation-extend-1.5.2.tgz",
+      "integrity": "sha512-aYgl6sQCmk7NsiizgpH9d5gMMisXjxy8GmUNh5NvvvbpaodlqojVJb4rY6IfKcJpAKzUUODQ5Vme9uPAbWjlZQ==",
       "requires": {
-        "rdf-string": "^1.3.1"
+        "sparqlee": "0.0.2"
+      }
+    },
+    "@comunica/actor-query-operation-filter-sparqlee": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-filter-sparqlee/-/actor-query-operation-filter-sparqlee-1.5.1.tgz",
+      "integrity": "sha512-BoFncqHwKcPW4MoH4TT+/6oYDjl/v/u7GpP9HOCcwjrgDbcuqt1wn5hYsMvs2cj30ECT9t5UuaHuYnoQum/JDw==",
+      "requires": {
+        "sparqlee": "0.0.2"
       }
     },
     "@comunica/actor-query-operation-from-quad": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.4.4.tgz",
-      "integrity": "sha512-e+rciTyaywA+8VPolBeRPcr7Tw/8wfw2d4Z9BN3d1nB8wt42bzPH5c+du3RWdj07CkVN7BSqDo3hh60GCEFjdA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-from-quad/-/actor-query-operation-from-quad-1.4.5.tgz",
+      "integrity": "sha512-TG7eDrrQ1XS+7Ut5pPExikdTipJSJICEmA0Nw+B7H5WjKEdND/GeMsvqLqk+u1AiHHJiR3kfjso5fEnzM4OUyw==",
       "requires": {
         "lodash.find": "^4.6.0",
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-join": {
@@ -971,9 +992,12 @@
       "integrity": "sha512-xTxusuDuLbE2mSxxmtPUInAkuKwcPgTkCZj7jif/j934qdo7Ar1lIZwQJL0AwgOdmMODn/9Z6/oiIrLMR/xKBA=="
     },
     "@comunica/actor-query-operation-leftjoin-nestedloop": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.4.4.tgz",
-      "integrity": "sha512-5xdGt1SR6PxaJaygVWFe9TIOwj+/jPX0MM0K9BjRYiUZCr6TxnRDlbs6VGYACMJr0da9MwBYldbqjj9DHQHSSw=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-leftjoin-nestedloop/-/actor-query-operation-leftjoin-nestedloop-1.5.1.tgz",
+      "integrity": "sha512-d4XeHYaaPG0Jt0yl34GbYUBeRFSw/G4lYa+u2SRRBFVDP6crrtqC0zQjNyFoL5cyZj5W64pRK5DpHNj8SJby2w==",
+      "requires": {
+        "sparqlee": "0.0.2"
+      }
     },
     "@comunica/actor-query-operation-minus": {
       "version": "1.4.4",
@@ -984,90 +1008,91 @@
         "asynciterator-promiseproxy": "^2.0.0"
       }
     },
-    "@comunica/actor-query-operation-orderby-direct": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-direct/-/actor-query-operation-orderby-direct-1.4.4.tgz",
-      "integrity": "sha512-+JvHFK2dtUbBLJxniZInVG1cGc7d4LK0eFHj0Jk69KUiIDjDJAjuMCQjBS2FdWNnS85NQ43a2NFwh3//iTqOvQ==",
+    "@comunica/actor-query-operation-orderby-sparqlee": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-orderby-sparqlee/-/actor-query-operation-orderby-sparqlee-1.5.1.tgz",
+      "integrity": "sha512-28e94juVJvEVIvTD0zDqzFpZo2V6csrGZ0qv1NU2HVOLdGNlXjoBPd/7K4kkkdeDC6h8zPXFeFUnnEIX+c2nsw==",
       "requires": {
-        "rdf-string": "^1.3.1"
+        "rdf-string": "^1.3.1",
+        "sparqlee": "0.0.2"
       }
     },
     "@comunica/actor-query-operation-path-alt": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.4.4.tgz",
-      "integrity": "sha512-fzvfXpJyrM0jR1SpEPG3f+BhXFfxI/n5T6fXxGuXlJIO+yG9bcnneALiSMiZkylLsmsVv7nJ58OYHnQQZvlEAA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-alt/-/actor-query-operation-path-alt-1.4.5.tgz",
+      "integrity": "sha512-3x3GLHISOtYwfHBudCz6TZGQNqB0jnnV/CYRIB61gnzLTDaI5Ts1bBNRklNQ77kjENq9EA02qOxXQnBQzbGQNg==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.4",
+        "@comunica/actor-abstract-path": "^1.4.5",
         "asynciterator-union": "^2.1.1",
         "lodash.uniq": "^4.5.0",
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-inv": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.4.4.tgz",
-      "integrity": "sha512-V1GVWc0sqLVvEynbZcPCqTPwFAuxVPOW4JZztMIYjKTx/pITsEgsoChz3RkuG3167P1j/zfPXEcr6x8Xe9NUTw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-inv/-/actor-query-operation-path-inv-1.4.5.tgz",
+      "integrity": "sha512-Ex/w1omPPo/HPqLPP1D+Weof60AEs5sYUe5PBaUwHnAiJycqyD9fMvFFgl08N5vg/EmaVZB0d5dgGSzgV5WE2A==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.4"
+        "@comunica/actor-abstract-path": "^1.4.5"
       }
     },
     "@comunica/actor-query-operation-path-link": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.4.4.tgz",
-      "integrity": "sha512-PxWk9Btd+MIgwva2AE0O3AGh2OtgYIo/uW5JzTBYx7Fz6Zvck7Z19Aqxc2KNZpft9X+alFriSWhuzRYHsko4kQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-link/-/actor-query-operation-path-link-1.4.5.tgz",
+      "integrity": "sha512-soXrhOH0Azc0QNhnlnFfqxMXhba2GNEDV3wOXWxQNgf1mc2SV1kkaTHzBgbWuEL3I4wzzMp2EbrWdZSzanPfxw==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.4",
-        "sparqlalgebrajs": "^1.3.1"
+        "@comunica/actor-abstract-path": "^1.4.5",
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-nps": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.4.4.tgz",
-      "integrity": "sha512-YnaKVcRjiobjtiu92REIakBJ6+SPIRfs2KpfmIUb7lfz1AGtLDxqjuwB3tt56ka3LOumP+xia0wXkyhxKMXcLg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-nps/-/actor-query-operation-path-nps-1.4.5.tgz",
+      "integrity": "sha512-vHl9GznWT0pW+KR/f9INfDo119OBjO1FLZxPlwWivo273WQtuVFfWQkL3iZToGIyUy7Aq3pLSh5kcvtRMIGj9w==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.4",
+        "@comunica/actor-abstract-path": "^1.4.5",
         "rdf-string": "^1.3.1",
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-one-or-more": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.4.4.tgz",
-      "integrity": "sha512-0d+Gj3tqPyqMEt45wMAE7hj5Fq6LsKkvGkljq30N0z8Ujtedy44ujczhEUSIkQKiaELBlURLx+mMSXF+tTXEhA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-one-or-more/-/actor-query-operation-path-one-or-more-1.4.5.tgz",
+      "integrity": "sha512-Tm+tdT4Zkvn/JZEFZ+X2nUc/nNFmKV1t+I3SaPSJVv3Z2/2CyjtA4SsuWaugo3IW5N9uDtIeOxGy4mhopo8myQ==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.4",
+        "@comunica/actor-abstract-path": "^1.4.5",
         "asynciterator": "^2.0.1",
         "asynciterator-promiseproxy": "^2.0.0",
         "rdf-string": "^1.3.1",
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-seq": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.4.4.tgz",
-      "integrity": "sha512-8W4klGzQy7G1Z/MSGslXZIZpAHrxwt71qizCxtXSoxlLMMWZ9eAhuvg/Qer2qfO/nGmc0psHMBGvaWo/XriAOw==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-seq/-/actor-query-operation-path-seq-1.4.5.tgz",
+      "integrity": "sha512-ihPQFDFPgDGYsBrwYcsJLv0hyDrJDYda6Dg17mnEtKGtk/TBn65Ev1A+YX1B3DPl5uUDWcEwrwZuIHzDrdssUw==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.4",
+        "@comunica/actor-abstract-path": "^1.4.5",
         "rdf-string": "^1.3.1",
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-more": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.4.4.tgz",
-      "integrity": "sha512-cBazaR2TDjNEhjvCSErSdYmAPrzV5ottovqBBGh/BZpH850qI9fVxgoE+U/ezdiJJhS59GiVZuX5743o+8GqBg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-more/-/actor-query-operation-path-zero-or-more-1.4.5.tgz",
+      "integrity": "sha512-RB+uoxnuvfCpoL3dzzlULrwqGfYPRQ4gSKjTKtkPm3yQEKzqoFp9q6HxGIilk8l1MddEnaHd30PnN/l3csarIg==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.4",
+        "@comunica/actor-abstract-path": "^1.4.5",
         "rdf-string": "^1.3.1",
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-path-zero-or-one": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.4.4.tgz",
-      "integrity": "sha512-srljARfJjV0GbMKGF58lXUynjHm08xYyHr3V7ba2eDWOt5KQB+Q2tNBdfVa1BcQrrTqXaRJClkjfLeEnJffQbg==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-path-zero-or-one/-/actor-query-operation-path-zero-or-one-1.4.5.tgz",
+      "integrity": "sha512-j4cTlPNDRKUybM5L4Uzqlid4Z4MhxwDhpGqF61v3Xs8icBO4F9JQGmgqNZy/CmT0QSdLycVfX/ubcNg69fb50w==",
       "requires": {
-        "@comunica/actor-abstract-path": "^1.4.4",
+        "@comunica/actor-abstract-path": "^1.4.5",
         "asynciterator": "^2.0.1",
         "rdf-string": "^1.3.1"
       }
@@ -1081,9 +1106,9 @@
       }
     },
     "@comunica/actor-query-operation-quadpattern": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.4.4.tgz",
-      "integrity": "sha512-nUQ3/4mvi0KBl24zhpp0aDCRDfCD15Psl+1MvOnId/9hAWJ46AjRbXkwgynZDa2nArTJDQRzpcAQDnBfwCElGw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-quadpattern/-/actor-query-operation-quadpattern-1.5.4.tgz",
+      "integrity": "sha512-LjLfIwOD2uoTMVOOWiXAaA04/drVXWcf6gq1rc4rDbxcJdAHGrbTpZi61GwHP4vCCk7f2U6I/64fI6BLrAjo4g==",
       "requires": {
         "asynciterator-promiseproxy": "^2.0.0",
         "rdf-string": "^1.3.1",
@@ -1091,12 +1116,27 @@
       }
     },
     "@comunica/actor-query-operation-reduced-hash": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.4.4.tgz",
-      "integrity": "sha512-8EhfuFBbiCiTgb4eHVSADuCUr93qHld3GZd/CK6X1q7lW7cU5YaFgCBRFb5vhmVInjAJ2IXwt7egTUDePn8j1A==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-reduced-hash/-/actor-query-operation-reduced-hash-1.4.5.tgz",
+      "integrity": "sha512-Nl8Uv1gRTAeZxvLOW6hlTUV2tm6qQtkanUgjxqNjoLSRTmOe7JqcQiKZg9vjgW82d8HUXYmzgvzMMezm3DAkaQ==",
       "requires": {
         "@comunica/actor-abstract-bindings-hash": "^1.4.4",
-        "lru-cache": "^4.1.3"
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
       }
     },
     "@comunica/actor-query-operation-service": {
@@ -1113,16 +1153,17 @@
       "integrity": "sha512-Ta9l2eOqgC1i2hOONWnlaUJ5EtDKEFJPV7G3zC7XCl0V4XBKXyMqpkXy9LXOJbPoMP1VvHdxoLNJ05xOSjHvtQ=="
     },
     "@comunica/actor-query-operation-sparql-endpoint": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.4.4.tgz",
-      "integrity": "sha512-TXi+WU1558j3PZ72qJ2W81KduXKRnZe7FVLQOUSFRYihLy/FxjN8vF8kNQfdRUSt7rEvJEUFhYreH/cYcyQVwQ==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-query-operation-sparql-endpoint/-/actor-query-operation-sparql-endpoint-1.5.4.tgz",
+      "integrity": "sha512-QCxckYzgiyOH+zvB0DyCEPYSW8Ls6Ebcz0Bx9Ez15IHyu5CSke4WtWZ+947Jw7ZOmcnM/yoVDJ+czsmvJ1Yahg==",
       "requires": {
+        "@comunica/utils-datasource": "^1.5.4",
         "arrayify-stream": "^1.0.0",
         "asynciterator": "^2.0.1",
         "fetch-sparql-endpoint": "^1.4.0",
         "rdf-string": "^1.3.1",
         "rdf-terms": "^1.4.0",
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-query-operation-union": {
@@ -1144,20 +1185,32 @@
       }
     },
     "@comunica/actor-rdf-dereference-http-parse": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.4.2.tgz",
-      "integrity": "sha512-2cKGrBY5cdkqV/puIdiR6625ANsDDrHSyqfOUuC4Ro3H2y65ieknZmC6ZKgQfD6Btg0WctKUMZD4sEFHBi3VFA==",
-      "requires": {
-        "node-web-streams": "^0.2.2"
-      }
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-http-parse/-/actor-rdf-dereference-http-parse-1.5.1.tgz",
+      "integrity": "sha512-hXqV3VOf0l6en/1LPODll0rT4kO1TMNYilAGP6aCa6NXdY0NOlqAJ4VgUkGuJUnfS09T/gYaU4R/KjZxzic58g=="
     },
     "@comunica/actor-rdf-dereference-paged-next": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-paged-next/-/actor-rdf-dereference-paged-next-1.4.4.tgz",
-      "integrity": "sha512-JFSzFXruSjVMvPNqrUfCxORNyr1t6jpKRWYnqvhseeqiI7mcFkuv+bFGn0Ue2HVHy0q/2PxPfDYx1GnL0BA6tQ==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-dereference-paged-next/-/actor-rdf-dereference-paged-next-1.4.5.tgz",
+      "integrity": "sha512-GJNBAB90XFExc5HKBs0oCUr749rHGQCjvZxWRH5CM6UFILfXvDt1GUvmWxWlVa4kcwqJQMvuVZioXvo9UqHMKg==",
       "requires": {
         "asynciterator": "^2.0.1",
-        "lru-cache": "^4.1.1"
+        "lru-cache": "^5.1.1"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A=="
+        }
       }
     },
     "@comunica/actor-rdf-join-nestedloop": {
@@ -1196,12 +1249,12 @@
       "integrity": "sha512-myi1b1Rz/5T22CBbklybJdqFTwUH4UJmPCP+YSUQ3JgJLnvBocRQW2PSNe7CgivWUyM/VGqoXD22SlaVaeIRZw=="
     },
     "@comunica/actor-rdf-parse-jsonld": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.4.3.tgz",
-      "integrity": "sha512-DN6gQNCCMVHWVyZccoYNdEFQU/wJOOtFu31LWg/KjO/LlOJW34ve4SE48Ed1VXPi16+diLXc92SMGelE99bwMA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-parse-jsonld/-/actor-rdf-parse-jsonld-1.5.4.tgz",
+      "integrity": "sha512-LEMls07dg9kPcTQVARI+9fNIb8peGCjucafi1BVpMdUfCo6UeiQJZlZEX9fkaC2aVFfS1UyXnm8WJ6Za09ymkQ==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
-        "jsonld": "^1.0.2",
+        "jsonld": "^1.5.0",
         "rdf-terms": "^1.4.0",
         "stream-to-string": "^1.1.0"
       }
@@ -1222,10 +1275,21 @@
         "rdfxml-streaming-parser": "^1.1.0"
       }
     },
+    "@comunica/actor-rdf-resolve-hypermedia-qpf": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-hypermedia-qpf/-/actor-rdf-resolve-hypermedia-qpf-1.5.4.tgz",
+      "integrity": "sha512-RjKscMWCqYNM3RraqRzp4l40acASoVI08bRpkoDjR8/HGfHiW9YMDveBIuKK/0Khvo0US25V1iIUWA4odZDUIg==",
+      "requires": {
+        "@rdfjs/data-model": "^1.1.0",
+        "asynciterator-promiseproxy": "^2.0.0",
+        "rdf-string": "^1.2.0",
+        "rdf-terms": "^1.2.0"
+      }
+    },
     "@comunica/actor-rdf-resolve-quad-pattern-federated": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.4.4.tgz",
-      "integrity": "sha512-Vg+RaO9TOzTZk89ak42VbVEONP+WuL0/UF6sRaplFvpCDodtim0hGTGwk1lk4eN980sv5qN8MmOGw/jsm4PTrA==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-federated/-/actor-rdf-resolve-quad-pattern-federated-1.5.4.tgz",
+      "integrity": "sha512-ndA/wI5t5vEmrCz+WJI1UsVy87Zx4LDMdgo5QUv1ZvQJLsj9PegTSrt17pBHJlNYAcAlIUcY9zp3xFWpHmCX8A==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "asynciterator": "^2.0.1",
@@ -1235,20 +1299,21 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-file": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-file/-/actor-rdf-resolve-quad-pattern-file-1.4.4.tgz",
-      "integrity": "sha512-smaI8AUDIwNaB3UUvIWm0u6bBChUBan6OscnLSCmizEUqxDiy0AmNQIvL+992FAQRjhxkBMvtQvF9gG94nKA5Q==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-file/-/actor-rdf-resolve-quad-pattern-file-1.5.4.tgz",
+      "integrity": "sha512-Hrozfm5UadDO03PKoKnljnfWHmhy5tB1W1pjc2IRmPZqyeE6Kfw6atP/7DwK4DN2HRvtOP3mmtlbxKO4gobOjA==",
       "requires": {
         "asynciterator": "^2.0.1",
         "n3": "^1.0.0",
         "rdf-string": "^1.3.1"
       }
     },
-    "@comunica/actor-rdf-resolve-quad-pattern-qpf": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-qpf/-/actor-rdf-resolve-quad-pattern-qpf-1.4.4.tgz",
-      "integrity": "sha512-ZrEQgXkVl2/UqIiPDSTmgTM2aBFVq+/A1tr12dV+g8Yprshp4Dchqe7Sw1UrDk0VkSDDBbXeOwy1yc54PWrCWg==",
+    "@comunica/actor-rdf-resolve-quad-pattern-hypermedia": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-hypermedia/-/actor-rdf-resolve-quad-pattern-hypermedia-1.5.4.tgz",
+      "integrity": "sha512-Kgrf2EN3QY1DKMeldLM0c8L+zJt4VQCj34HiHFns4XZCZ/GrdRdG8mQBnyiBIAn8iJD3Nm/c5syqBV0X7+9/yw==",
       "requires": {
+        "@comunica/utils-datasource": "^1.5.4",
         "@rdfjs/data-model": "^1.1.1",
         "asynciterator-promiseproxy": "^2.0.0",
         "rdf-string": "^1.3.1",
@@ -1256,26 +1321,25 @@
       }
     },
     "@comunica/actor-rdf-resolve-quad-pattern-sparql-json": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.4.4.tgz",
-      "integrity": "sha512-TVIpyldS40sB1CmcpwIIJj37AWVpYXj5SMnQh5k/IKws73IRWezjPM/JQ9q1bj1xCLIuC5JTBGkJ2HE8ZYUgrw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-resolve-quad-pattern-sparql-json/-/actor-rdf-resolve-quad-pattern-sparql-json-1.5.4.tgz",
+      "integrity": "sha512-XpAV3cNvBJEcjTFwEMHotimQ7KpPVhjNv2BQIetGflcxE4uQxfdsrHv9BeUqwkLI4TA+/0cRoB/jNio52ysElg==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "asynciterator": "^2.0.1",
         "asynciterator-promiseproxy": "^2.0.0",
-        "node-web-streams": "^0.2.2",
         "rdf-terms": "^1.4.0",
-        "sparqlalgebrajs": "^1.3.1",
+        "sparqlalgebrajs": "^1.4.0",
         "sparqljson-parse": "^1.5.0"
       }
     },
     "@comunica/actor-rdf-serialize-jsonld": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.4.0.tgz",
-      "integrity": "sha512-6peJZEldsxv1m52iPOb7bVu/4AqCNhu2+Amn7Cq7sJJDBoKwCncPC7fmh8Nvs+mEauO8ohvWriCsYzpZ8aCtgw==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-serialize-jsonld/-/actor-rdf-serialize-jsonld-1.5.4.tgz",
+      "integrity": "sha512-dhJFXy11W1UK7TWGwnL36a53Epvg6zJdj7y2gu4Ul0i1ArKrdDeLgw+eNkjWVJm0Pk2bqLHhm53K40BZks3Qug==",
       "requires": {
         "arrayify-stream": "^1.0.0",
-        "jsonld": "^1.0.2",
+        "jsonld": "^1.5.0",
         "streamify-array": "^1.0.0"
       }
     },
@@ -1289,37 +1353,37 @@
       }
     },
     "@comunica/actor-rdf-source-identifier-file-content-type": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-file-content-type/-/actor-rdf-source-identifier-file-content-type-1.4.0.tgz",
-      "integrity": "sha512-OCMsb2iN6qtHHEXoovO50g1hWNQID9KFGa8a2/dHl74nWb+gDIgS71mEtj23kCJDkak3VQw9Hz2Z0T7221LmkA=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-file-content-type/-/actor-rdf-source-identifier-file-content-type-1.5.1.tgz",
+      "integrity": "sha512-w5wek/kJb4ulncUfRSYFh3bbcMq1NyUssv6GLl48AZZPQ9PSBCHq4zb5iO8aXFF2Tm11kvuN46COsdlVy7gAYA=="
     },
     "@comunica/actor-rdf-source-identifier-hypermedia-qpf": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-hypermedia-qpf/-/actor-rdf-source-identifier-hypermedia-qpf-1.4.0.tgz",
-      "integrity": "sha512-0ta8K55Fpmo40pHWZzSnZmboaCQRxMhPTS02TfbUdRft8WZARvO0FqtEX/sKCuJdshJIUh4Ao8l8bIXSM24yWA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-hypermedia-qpf/-/actor-rdf-source-identifier-hypermedia-qpf-1.5.1.tgz",
+      "integrity": "sha512-L1OaaGfDS6pZqYg6Lr5woL51nmsQmZL5oah9Q8qZZzLMM/cGnFlH0rN+byhlLca8OJNsOR0GUjpgZhezgV7hnA==",
       "requires": {
         "stream-to-string": "^1.1.0"
       }
     },
     "@comunica/actor-rdf-source-identifier-sparql": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-sparql/-/actor-rdf-source-identifier-sparql-1.4.0.tgz",
-      "integrity": "sha512-3KTZrfGsmZI+hGOzzHRohuboKVAXkOGgVO6rgKW2XV9mtTeOrfxD4mGH9A/OD6cdsTJDtVk//UsuUkhEnyc/cg=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-rdf-source-identifier-sparql/-/actor-rdf-source-identifier-sparql-1.5.1.tgz",
+      "integrity": "sha512-i7yhFmppBhS3HlXow+BsjNZN7tAhiQDBpxLKTk4cTD7R/Dt9olxalP86rqsZMOh0PbvC0JwrMVaMrbRsHQlKnQ=="
     },
     "@comunica/actor-sparql-parse-algebra": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.4.3.tgz",
-      "integrity": "sha512-cEqOkCdoX03mw8dR3bIqMtPR1DMmFBKBewSDCZFm9AkOvopAhglZRyVNULuwQu0AJfZAnxncPQcTKCT3lMxslw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-algebra/-/actor-sparql-parse-algebra-1.5.3.tgz",
+      "integrity": "sha512-75tma3F1qxzF4wVf0WcsZA6p6N7ixkQjRnf3bwKOFcNzqLrsEUmgGBjrOvpK0tR1ZW5CT2faAGwJ0tUnPEFV9w==",
       "requires": {
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.0"
       }
     },
     "@comunica/actor-sparql-parse-graphql": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.4.3.tgz",
-      "integrity": "sha512-ZfVt8ByHGQhEQNqjt2k/S7uzx4+p92fuM41tN7nMQBVNVE8aPtMDeiVD818dK2/pOymUfBma9O4AhmHXr095Mw==",
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@comunica/actor-sparql-parse-graphql/-/actor-sparql-parse-graphql-1.5.3.tgz",
+      "integrity": "sha512-Bhtw+40XwB9Ei8Gh/b0u8EI6iGDNOYHroEucheCKORKSq9bwvUm+dk2S3Gew1k4lNfmjzFOW0Lu8umU/IUCUQg==",
       "requires": {
-        "graphql-to-sparql": "^1.4.1"
+        "graphql-to-sparql": "^1.5.0"
       }
     },
     "@comunica/actor-sparql-serialize-json": {
@@ -1380,14 +1444,26 @@
       "integrity": "sha512-5fNGyLXhCZSD6xf7V5AUWWGu3Vhj1Ga/TNZu6nCCLhFlxWzQvqnCBOGlAiVrWqLlzMp4HSJbtwLo6FUz6Zkzwg=="
     },
     "@comunica/bus-http": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.4.0.tgz",
-      "integrity": "sha512-paeLBt/4ArNvj/348cuUm1VYG494WcQhiXTTD69GD6ienxizAbisYSWhmSDNOPtS/atLBcifx8uoyREOLrs0sw=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-http/-/bus-http-1.5.1.tgz",
+      "integrity": "sha512-t/UeakUThpXutbgvAduMXD8VjdnHOcjF34QAuNuEE647q3LjrQLtYBAoJZUs8b47LtU2spXIrY0ho3IE9xADAQ==",
+      "requires": {
+        "is-stream": "^1.1.0",
+        "node-web-streams": "^0.2.2"
+      }
     },
     "@comunica/bus-init": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@comunica/bus-init/-/bus-init-1.4.0.tgz",
       "integrity": "sha512-NPjWh6x5w+EqMVC7Wy5hj2pRLEsRuxy+9IThBRrQhJCnrWxA6+iz06N+7Kcyfp5796ueCM60i5j4DgcCIQDk5Q=="
+    },
+    "@comunica/bus-optimize-query-operation": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-optimize-query-operation/-/bus-optimize-query-operation-1.5.0.tgz",
+      "integrity": "sha512-+75LI5G8Qu0PkxwwTWaMYlFJFbitMybSi8DOxezg0P+mGgO9tejcYUTsQeG+8Po3HhzAn3c/XXOxkOb70dqMgA==",
+      "requires": {
+        "sparqlalgebrajs": "^1.4.0"
+      }
     },
     "@comunica/bus-query-operation": {
       "version": "1.4.4",
@@ -1435,13 +1511,22 @@
         "@comunica/actor-abstract-mediatyped": "^1.4.0"
       }
     },
+    "@comunica/bus-rdf-resolve-hypermedia": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-hypermedia/-/bus-rdf-resolve-hypermedia-1.5.4.tgz",
+      "integrity": "sha512-WOYMfDyQdPLgrg43/nB7QfkJlfVCWOVIvlM8jDXfz3O3yg2WiQ6KnnHPXHMKfh0U0zTbIIzhjGkdqBAQzbSLLg==",
+      "requires": {
+        "asynciterator": "^2.0.0",
+        "asyncreiterable": "^1.1.1"
+      }
+    },
     "@comunica/bus-rdf-resolve-quad-pattern": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.4.4.tgz",
-      "integrity": "sha512-R7YmzIhtAcZQ48SVh8Y1zGlW0g0R3B34NQDmeyVMVbzwlbz/AbnlnR4Ybc8nKXX3O2a/59/5um+HUlj4ohoNkg==",
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-resolve-quad-pattern/-/bus-rdf-resolve-quad-pattern-1.5.4.tgz",
+      "integrity": "sha512-UKEMvY033et92wDgc7oR5JejzyNpSHxA+FL3HwwgyEMKf4rdXfl+/FwS6BcDRsmIKnoKxPa0SAn/ZXRIQTH5zg==",
       "requires": {
         "asynciterator": "^2.0.1",
-        "asyncreiterable": "^1.1.0"
+        "asyncreiterable": "^1.1.1"
       }
     },
     "@comunica/bus-rdf-serialize": {
@@ -1453,9 +1538,9 @@
       }
     },
     "@comunica/bus-rdf-source-identifier": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-source-identifier/-/bus-rdf-source-identifier-1.4.0.tgz",
-      "integrity": "sha512-BNBlCPX55G3F1Bd1+U536t7apEKCMpGcw+fgxKHvNXxrO5FdmkGr4933eVEeAJ5eR1PO5T7mEFMmTkmLAFRpuQ=="
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/@comunica/bus-rdf-source-identifier/-/bus-rdf-source-identifier-1.5.1.tgz",
+      "integrity": "sha512-X2SjIG+d3EE8xgLJetUIQuSKGBPk28KO9SKNNqySSw3C3RBLJeYkK+1clUTqxE1tvBox55D6Fjv6A6kZJ8jszg=="
     },
     "@comunica/bus-sparql-parse": {
       "version": "1.4.0",
@@ -1537,6 +1622,16 @@
         "@comunica/runner": "^1.4.4"
       }
     },
+    "@comunica/utils-datasource": {
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@comunica/utils-datasource/-/utils-datasource-1.5.4.tgz",
+      "integrity": "sha512-D7+aMGKNFzrwE4RZfHdZoFoA41x/wuZArSmZnMw92i6SEDRLovUkHReoXKwRwHH6UekZPpZmp9hKcWMl5gfvcA==",
+      "requires": {
+        "arrayify-stream": "^1.0.0",
+        "asynciterator": "^2.0.0",
+        "asyncreiterable": "^1.1.1"
+      }
+    },
     "@rdfjs/data-model": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@rdfjs/data-model/-/data-model-1.1.1.tgz",
@@ -1605,10 +1700,37 @@
         "text-encoding": "^0.6.1"
       }
     },
+    "@types/asynciterator": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@types/asynciterator/-/asynciterator-1.1.1.tgz",
+      "integrity": "sha512-KgjXxTtWbMW7UA4oZauIfg2rCl5+5LbsoVF5DwwpXVQxzSbez2PQ9NAlbJlBjIHqKLOpWcdjqL+wyrNepvTZOg==",
+      "requires": {
+        "@types/events": "*",
+        "@types/node": "*"
+      }
+    },
+    "@types/events": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-3.0.0.tgz",
+      "integrity": "sha512-EaObqwIvayI5a8dCzhFrjKzVwKLxjoG9T6Ppd5CEo07LRKfQ8Yokw54r5+Wq7FaBQ+yXRvQAYPrHwya1/UFt9g=="
+    },
+    "@types/lodash": {
+      "version": "4.14.120",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.120.tgz",
+      "integrity": "sha512-jQ21kQ120mo+IrDs1nFNVm/AsdFxIx2+vZ347DbogHJPd/JzKNMOqU6HCYin1W6v8l5R9XSO2/e9cxmn7HAnVw=="
+    },
+    "@types/lodash.isequal": {
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/@types/lodash.isequal/-/lodash.isequal-4.5.3.tgz",
+      "integrity": "sha512-tpTUmHksO2H9RF98Y2w7v06ZeEKAxHPo2ysL0bV5qv5UBweiZl33NFu5QYmYOSxSnHMqBt/vsVsBVeQAcJiokg==",
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/node": {
-      "version": "10.12.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.10.tgz",
-      "integrity": "sha512-8xZEYckCbUVgK8Eg7lf5Iy4COKJ5uXlnIOnePN0WUwSQggy9tolM+tDJf7wMOnT/JT/W9xDYIaYggt3mRV2O5w=="
+      "version": "10.12.20",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.12.20.tgz",
+      "integrity": "sha512-9spv6SklidqxevvZyOUGjZVz4QRXGu2dNaLyXIFzFYZW0AGDykzPRIUFJXTlQXyfzAucddwTcGtJNim8zqSOPA=="
     },
     "@types/rdf-js": {
       "version": "2.0.1",
@@ -2159,9 +2281,9 @@
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "asyncreiterable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/asyncreiterable/-/asyncreiterable-1.1.0.tgz",
-      "integrity": "sha512-JvcNg9Dbra1h+WNsDUt8HlbSe1IsibzdBh35g9VxdceHuquVKK20kiQI3CFxoGUQq3Mwt+cscPAFgK1J8MraMA==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/asyncreiterable/-/asyncreiterable-1.1.1.tgz",
+      "integrity": "sha512-/HWKlJY/qDMB5pfZL6fLqMmGexu6uxvc7LJkG/uO9hbxVlV4AQ3kRSz/JypRdJPkx5lLT1HaI9qf2t93SSABxg==",
       "requires": {
         "asynciterator": "^2.0.0"
       }
@@ -5081,23 +5203,23 @@
       "dev": true
     },
     "graphql": {
-      "version": "14.0.2",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.0.2.tgz",
-      "integrity": "sha512-gUC4YYsaiSJT1h40krG3J+USGlwhzNTXSb4IOZljn9ag5Tj+RkoXrWp+Kh7WyE3t1NCfab5kzCuxBIvOMERMXw==",
+      "version": "14.1.1",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-14.1.1.tgz",
+      "integrity": "sha512-C5zDzLqvfPAgTtP8AUPIt9keDabrdRAqSWjj2OPRKrKxI9Fb65I36s1uCs1UUBFnSWTdO7hyHi7z1ZbwKMKF6Q==",
       "requires": {
         "iterall": "^1.2.2"
       }
     },
     "graphql-to-sparql": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-1.4.1.tgz",
-      "integrity": "sha512-Jk4gfE1BbqQiOsEhgwufinlC4WefJb29JzcX7QoTxxgw8/ddz0N7IvMd2V56oNuKyZUj8sDKAhgUNjUVEpc/VA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/graphql-to-sparql/-/graphql-to-sparql-1.5.0.tgz",
+      "integrity": "sha512-NhXHDMPO1Zw0a7kyu5/CndxNi5daZb+/dru1ECCms2tSA1qedF19HZwrkqZISgBlxcBoovSH4BFRodNEpAsu4Q==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "@types/rdf-js": "^2.0.1",
         "graphql": "^14.0.0",
         "minimist": "^1.2.0",
-        "sparqlalgebrajs": "^1.3.1"
+        "sparqlalgebrajs": "^1.4.2"
       }
     },
     "growly": {
@@ -7191,11 +7313,11 @@
       }
     },
     "ldflex-comunica": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/ldflex-comunica/-/ldflex-comunica-1.0.1.tgz",
-      "integrity": "sha512-Tdqt3FTy0BZbsmCErZQwziv4ZKSwWVFBvVTjn9O/UxT+vtCyKwUnqS5amb/F/NH9X3gQyuDgZEXY/fmV+0Uq9w==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ldflex-comunica/-/ldflex-comunica-1.1.0.tgz",
+      "integrity": "sha512-1yjtrQzinrytWvbPRGrO4uksR2WFhjk182qGZ3a0Q+dojHomkGsToPCv5jIycsB9or/Wfzxw2FmV7u3x+TOrCA==",
       "requires": {
-        "@comunica/actor-init-sparql": "^1.3.0"
+        "@comunica/actor-init-sparql": "^1.5.0"
       }
     },
     "left-pad": {
@@ -7377,6 +7499,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
       "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "dev": true,
       "requires": {
         "pseudomap": "^1.0.2",
         "yallist": "^2.1.2"
@@ -7699,9 +7822,9 @@
       "dev": true
     },
     "n3": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/n3/-/n3-1.0.1.tgz",
-      "integrity": "sha512-2suWrEdCpe6BYKcPBEQgGV+BKO9GkgkNpEQ3xC2iSHti4Qb4bxHm3XRFLJP8u1MdBZv3EFs/WaNH34pFBoKm1Q=="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/n3/-/n3-1.0.3.tgz",
+      "integrity": "sha512-IdcCNqb/1gj9fX63hoVEn3/Z1u9iLJiYLSpesmqT3+5UrxcYG5YldUP6T2okNRZKzyVdqz+I0PExGkWkz9gcZw=="
     },
     "nan": {
       "version": "2.11.1",
@@ -8649,7 +8772,8 @@
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
-      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
+      "dev": true
     },
     "psl": {
       "version": "1.1.29",
@@ -8824,9 +8948,9 @@
       }
     },
     "rdfxml-streaming-parser": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.1.0.tgz",
-      "integrity": "sha512-0cMdocZQoqx6052vnFAh9fo0bVcRJbav6UVRCeAJiNQoRjNhvY/QwwIPPrk60h+oN7gUKJLk6adFQRBTjJJLqQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/rdfxml-streaming-parser/-/rdfxml-streaming-parser-1.2.0.tgz",
+      "integrity": "sha512-HhgQ+eG9mfJgmAKCTHml47oSPJb2yAbqy01UWPcEwzb+ktvFbvTvjBSzMCmN9vitBenFBEsqfq1DPkEtXRv26g==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "relative-to-absolute-iri": "^1.0.0",
@@ -9030,9 +9154,9 @@
       }
     },
     "relative-to-absolute-iri": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.0.tgz",
-      "integrity": "sha512-Yt4tG3eoy0R8111kS2G/jH3QE48U7RIAqGQLqek4LbA4MYKy5OXKVKJgAxu5tmZVengPHiaiP4R8tg1zZhXE+A=="
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/relative-to-absolute-iri/-/relative-to-absolute-iri-1.0.2.tgz",
+      "integrity": "sha512-2tAsyCpb/ozT6w8BSaz//u7iRIW621FsMbC8el4VqzvtuntevEFfWNM/Wr9ubodzGa9OwBNwOHERRKqw9toKOA=="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
@@ -9799,21 +9923,37 @@
       "dev": true
     },
     "sparqlalgebrajs": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-1.3.1.tgz",
-      "integrity": "sha512-sG7lrzOW4Yk0bWXL5pt8DoA4eMHweLuYDif1sF0tOC412rftTKxD8HtoZybHORiBXylfFMl7OQsrh0GVjAnmZg==",
+      "version": "1.4.2",
+      "resolved": "https://registry.npmjs.org/sparqlalgebrajs/-/sparqlalgebrajs-1.4.2.tgz",
+      "integrity": "sha512-gkLgH4T1exMRl0MAvCBePnkOx2WVj8lYwME1mxNEcgC2TPHuOMuImDJgnM2RJ+nZfbQ1CRsEe8y9UQJz06QLnw==",
       "requires": {
         "@rdfjs/data-model": "^1.1.1",
         "lodash.isequal": "^4.5.0",
         "minimist": "^1.2.0",
         "rdf-string": "^1.3.1",
-        "sparqljs": "^2.0.3"
+        "sparqljs": "^2.2.1"
+      }
+    },
+    "sparqlee": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/sparqlee/-/sparqlee-0.0.2.tgz",
+      "integrity": "sha512-4Gi30lGMgqfxuDUn0V4bFraA+Rk7auJQsW5uy3Pf0wBCv8BqePVdPHsfSUY+ycRDGcMx1hivvs83Oh8NMYTwRg==",
+      "requires": {
+        "@rdfjs/data-model": "^1.1.0",
+        "@types/asynciterator": "^1.1.0",
+        "@types/lodash": "^4.14.105",
+        "@types/lodash.isequal": "^4.5.2",
+        "@types/node": "^10.11.4",
+        "@types/rdf-js": "^2.0.1",
+        "immutable": "^3.8.2",
+        "rdf-string": "^1.1.1",
+        "sparqlalgebrajs": "^1.1.0"
       }
     },
     "sparqljs": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-2.1.0.tgz",
-      "integrity": "sha512-WXb2utLh6A9tbpkz4I23grNuv42fh2ttxGONLz1mz5TvZtJEelody0jEpC7U84cZZn+sNqOQSTdv+kcESHlGqw=="
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/sparqljs/-/sparqljs-2.2.1.tgz",
+      "integrity": "sha512-nvwCxdqZbggDEFc/1b4FfAUxAzBjAkpruDRwqQSMApyvr94qxta6DG9hCFI423i/1wJkPi5pggLmN0q2YdgpCg=="
     },
     "sparqljson-parse": {
       "version": "1.5.0",
@@ -10077,9 +10217,9 @@
       "dev": true
     },
     "stream-to-string": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.1.0.tgz",
-      "integrity": "sha1-OSELATF+ars16FRTjgEwN7ajWUA=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-string/-/stream-to-string-1.2.0.tgz",
+      "integrity": "sha512-8drZlFIKBHSMdX9GCWv8V9AAWnQcTqw0iAI6/GC7UJ0H0SwKeFKjOoZfGY1tOU00GGU7FYZQoJ/ZCUEoXhD7yQ==",
       "requires": {
         "promise-polyfill": "^1.1.6"
       }
@@ -11765,7 +11905,8 @@
     "yallist": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
-      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
+      "dev": true
     },
     "yargs": {
       "version": "11.1.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "ldflex": "^1.3.0",
-    "ldflex-comunica": "^1.0.1",
+    "ldflex-comunica": "^1.1.0",
     "solid-auth-client": "^2.2.9",
     "uuid": "^3.3.2"
   },

--- a/src/ComunicaUpdateEngine.js
+++ b/src/ComunicaUpdateEngine.js
@@ -1,0 +1,47 @@
+import ComunicaEngine from 'ldflex-comunica';
+import auth from 'solid-auth-client';
+
+/**
+ * An extension of ComunicaEngine that delegates
+ * SPARQL UPDATE queries directly to the documents
+ * using authenticated request.
+ */
+export default class ComunicaUpdateEngine extends ComunicaEngine {
+  constructor(subject) {
+    super(subject);
+  }
+
+  /**
+   * Delegates SPARQL UPDATE queries directly to the document.
+   */
+  executeUpdate(sparql) {
+    let executed = false;
+    const next = async () => {
+      if (!executed) {
+        executed = true;
+
+        // Send authenticated PATCH request to the document
+        const document = this.getDocument(await this._subject);
+        const response = await auth.fetch(document, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/sparql-update',
+          },
+          body: sparql,
+        });
+
+        // Error if the server response was not ok
+        if (!response.ok)
+          throw new Error(`Update query failed (${response.status}): ${response.statusText}`);
+
+        // Mock Comunica's response for bindings as a Immutable.js object.
+        return { value: { size: 1, values: () => ({ next: () => ({ value: { ok: true } }) }) } };
+      }
+      return { done: true };
+    };
+    return {
+      next,
+      [Symbol.asyncIterator]() { return this; },
+    };
+  }
+}

--- a/src/SubjectPathResolver.js
+++ b/src/SubjectPathResolver.js
@@ -1,4 +1,4 @@
-import ComunicaEngine from 'ldflex-comunica';
+import ComunicaUpdateEngine from './ComunicaUpdateEngine';
 
 /**
  * LDflex property resolver that returns a new path
@@ -15,7 +15,7 @@ export default class SubjectPathResolver {
   }
 
   resolve(subject) {
-    const queryEngine = new ComunicaEngine(subject);
+    const queryEngine = new ComunicaUpdateEngine(subject);
     return this._paths.create({ queryEngine }, { subject });
   }
 

--- a/test/ComunicaUpdateEngine-test.js
+++ b/test/ComunicaUpdateEngine-test.js
@@ -1,0 +1,63 @@
+import ComunicaUpdateEngine from '../src/ComunicaUpdateEngine';
+import auth from 'solid-auth-client';
+
+describe('a ComunicaUpdateEngine instance', () => {
+  let engine;
+  beforeEach(() => (engine = new ComunicaUpdateEngine('http://example.org')));
+
+  describe('Inserting a triple', () => {
+    beforeEach(async () => {
+      for await (const bindings of engine.executeUpdate('INSERT DATA { <> <> <> }')) {
+        expect(bindings.size).toBe(1);
+        expect(bindings.values().next().value.ok).toBe(true);
+      }
+    });
+
+    it('issues a PATCH request', () => {
+      expect(auth.fetch).toHaveBeenCalledTimes(1);
+      const args = auth.fetch.mock.calls[0];
+      expect(args[1]).toHaveProperty('method', 'PATCH');
+    });
+
+    it('sets the Content-Type to application/sparql-update', () => {
+      expect(auth.fetch).toHaveBeenCalledTimes(1);
+      const args = auth.fetch.mock.calls[0];
+      expect(args[1]).toHaveProperty('headers');
+      expect(args[1].headers).toHaveProperty('Content-Type', 'application/sparql-update');
+    });
+
+    it('sends a patch document', () => {
+      expect(auth.fetch).toHaveBeenCalledTimes(1);
+      const args = auth.fetch.mock.calls[0];
+      expect(args[1]).toHaveProperty('body');
+      expect(args[1].body).toEqual('INSERT DATA { <> <> <> }');
+    });
+  });
+
+  describe('Inserting an invalid query', () => {
+    beforeEach(async () => {
+      expect(engine.executeUpdate('error').next()).rejects
+        .toThrow(new Error('Update query failed (123): Status'));
+    });
+
+    it('issues a PATCH request', () => {
+      expect(auth.fetch).toHaveBeenCalledTimes(1);
+      const args = auth.fetch.mock.calls[0];
+      expect(args[1]).toHaveProperty('method', 'PATCH');
+    });
+
+    it('sets the Content-Type to application/sparql-update', () => {
+      expect(auth.fetch).toHaveBeenCalledTimes(1);
+      const args = auth.fetch.mock.calls[0];
+      expect(args[1]).toHaveProperty('headers');
+      expect(args[1].headers).toHaveProperty('Content-Type', 'application/sparql-update');
+    });
+
+    it('sends a patch document', () => {
+      expect(auth.fetch).toHaveBeenCalledTimes(1);
+      const args = auth.fetch.mock.calls[0];
+      expect(args[1]).toHaveProperty('body');
+      expect(args[1].body).toEqual('error');
+    });
+  });
+});

--- a/test/__mocks__/solid-auth-client.js
+++ b/test/__mocks__/solid-auth-client.js
@@ -1,4 +1,4 @@
 export default {
   currentSession: jest.fn(),
-  fetch: jest.fn(),
+  fetch: jest.fn((request, init) => ({ ok: !init || init.body !== 'error', status: 123, statusText: 'Status' })),
 };


### PR DESCRIPTION
This makes it so that SPARQL UPDATE queries are sent to the document directly as a PATCH request.

_https://github.com/RubenVerborgh/LDflex-Comunica/pull/2 should be merged first, and the `ldflex-comunica` dependency should then be bumped._
_And probabably also https://github.com/RubenVerborgh/LDflex/pull/6_