### PR TITLE
Invalidate Comunica caches after update queries

### DIFF
--- a/src/ComunicaUpdateEngine.js
+++ b/src/ComunicaUpdateEngine.js
@@ -33,6 +33,9 @@ export default class ComunicaUpdateEngine extends ComunicaEngine {
         if (!response.ok)
           throw new Error(`Update query failed (${response.status}): ${response.statusText}`);
 
+        // Invalidate Comunica's internal caches, as they may have changed because of the update
+        await this._engine.invalidateHttpCache(document);
+
         // Mock Comunica's response for bindings as a Immutable.js object.
         return { value: { size: 1, values: () => ({ next: () => ({ value: { ok: true } }) }) } };
       }

--- a/test/ComunicaUpdateEngine-test.js
+++ b/test/ComunicaUpdateEngine-test.js
@@ -37,6 +37,12 @@ describe('a ComunicaUpdateEngine instance', () => {
       expect(args[1]).toHaveProperty('body');
       expect(args[1].body).toEqual('INSERT DATA { <> <> <> }');
     });
+
+    it('invalidates the document cache', () => {
+      expect(engine._engine.invalidateHttpCache).toHaveBeenCalledTimes(1);
+      const args = engine._engine.invalidateHttpCache.mock.calls[0];
+      expect(args[0]).toEqual('https://example.org/');
+    });
   });
 
   describe('Inserting an invalid query', () => {

--- a/test/__mocks__/ldflex-comunica.js
+++ b/test/__mocks__/ldflex-comunica.js
@@ -1,6 +1,9 @@
 export default class ComunicaEngineMock {
   constructor(subject, source) {
     this._source = source;
+    this._engine = {
+      invalidateHttpCache: jest.fn(() => Promise.resolve(true)),
+    };
   }
 
   getDocument() {


### PR DESCRIPTION
This requires https://github.com/RubenVerborgh/LDflex-Comunica/pull/11

Closes RubenVerborgh/LDflex-Comunica#10

:tada:
<img width="417" alt="screen shot 2019-02-22 at 10 34 27" src="https://user-images.githubusercontent.com/440384/53233536-eca47400-368d-11e9-9016-18d5940b3689.png">
