### PR TITLE
Added ability to provide custom context

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,20 @@ async function showProfile(person) {
 
 ```
 
+#### With a custom context
+```javascript
+const { withCustomContext } = require('@solid/query-ldflex);
+
+const context = {
+  "@context": {
+    "@vocab": "http://xmlns.com/foaf/0.1/",
+    "friends": "knows",
+    "label": "http://www.w3.org/2000/01/rdf-schema#label",
+  }
+};
+const data = withCustomContext(context);
+```
+
 ### In the browser
 ```html
 <script src="solid-auth-client.bundle.js"></script>

--- a/package-lock.json
+++ b/package-lock.json
@@ -3584,8 +3584,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -5200,8 +5199,7 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
@@ -5230,7 +5228,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7219,7 +7216,6 @@
       "resolved": "https://registry.npmjs.org/minipass/-/minipass-2.3.5.tgz",
       "integrity": "sha512-Gi1W4k059gyRbyVUZQ4mEqLm0YIUiGYfvxhF6SIlk3ui1WVxMTGfGdQ2SInh3PDrRTVvPKgULkpJtT4RH10+VA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "safe-buffer": "^5.1.2",
         "yallist": "^3.0.0"
@@ -7548,7 +7544,7 @@
       "integrity": "sha1-CH52u+t+jcVmhrJdtOYMX/nbCR8=",
       "requires": {
         "is-stream": "^1.1.0",
-        "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill.git#spec_performance_improvements"
+        "web-streams-polyfill": "git://github.com/gwicke/web-streams-polyfill.git#42c488428adea1dc0c0245014e4896ad456b1ded"
       }
     },
     "nopt": {

--- a/src/index.js
+++ b/src/index.js
@@ -47,27 +47,31 @@ const subjectPathFactory = new PathFactory({
 });
 
 // Export the root path that resolves the first property access
-export default rootPath = new PathFactory({
-  // Handlers of specific named properties
-  handlers: {
-    ...defaultHandlers,
+export default rootPath = withCustomContext(context);
 
-    // The `from` property takes a source URI as input
-    from: new SourcePathHandler(subjectPathFactory),
-    // The `user` property starts a path with the current user as subject
-    user: new UserPathHandler(subjectPathFactory),
+export function withCustomContext(customContext) {
+  return new PathFactory({
+    // Handlers of specific named properties
+    handlers: {
+      ...defaultHandlers,
 
-    // Clears the cache for the given document (or everything, if undefined)
-    clearCache: ({ settings }) => doc => settings.queryEngine.clearCache(doc),
+      // The `from` property takes a source URI as input
+      from: new SourcePathHandler(subjectPathFactory),
+      // The `user` property starts a path with the current user as subject
+      user: new UserPathHandler(subjectPathFactory),
 
-    // Expose the JSON-LD context
-    context: () => context,
-  },
-  // Handlers of all remaining properties
-  resolvers: [
-    // `data[url]` starts a path with the property as subject
-    new SubjectPathResolver(subjectPathFactory),
-  ],
-  // Global query engine (currently only used for clearing the cache)
-  queryEngine: new ComunicaUpdateEngine(),
-}).create();
+      // Clears the cache for the given document (or everything, if undefined)
+      clearCache: ({ settings }) => doc => settings.queryEngine.clearCache(doc),
+
+      // Expose the JSON-LD context
+      context: () => customContext,
+    },
+    // Handlers of all remaining properties
+    resolvers: [
+      // `data[url]` starts a path with the property as subject
+      new SubjectPathResolver(subjectPathFactory),
+    ],
+    // Global query engine (currently only used for clearing the cache)
+    queryEngine: new ComunicaUpdateEngine(),
+  }).create();
+}


### PR DESCRIPTION
WARNING: DO NOT MERGE

This doesn't work but I wanted to open the pull request for discussion.

I'd like to use the functionality for auth from this library, but provide my own context so that I can use attributes that aren't currently in the context file.

This doesn't work because the default export is a Proxy and will supersede any attributes for non-default exports.

@RubenVerborgh Is this a feature that seems apt?